### PR TITLE
ci: Initialize goreleaser configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # binary
 /slurp
 /slurp.exe
+
+# goreleaser aritifact directory shouldn't be in source
+/dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,52 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - formats: [tar.gz]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - LICENSE.md
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  footer: >-
+
+    ---
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,22 @@
+# Releasing
+
+## Steps
+
+1. Ensure you have the most current main branch
+   - This command assumes [slurp's](https://github.com/VyrCossont/slurp) remote
+     is origin.
+   - `git checkout main && git pull origin main`
+2. Create a valid [semver](https://semver.org/) tag
+   - `git tag -a v${VERSION} -m "$RELEASE_MESSAGE_HERE"`
+   - `git push origin v${VERSION}`
+3. Authenticate to GitHub and set GITHUB_TOKEN
+   - `export GITHUB_TOKEN=$YOUR_TOKEN_HERE`
+4. Run goreleaser
+   - `goreleaser release`
+
+You will now have created a github release!
+
+## References
+
+- [goreleaser quick start](https://goreleaser.com/quick-start/)
+- [goreleaser documentation](https://goreleaser.com/customization/)

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/vincent-petithory/dataurl v1.0.0
 	github.com/zalando/go-keyring v0.2.6
+	golang.org/x/net v0.34.0
 	golang.org/x/time v0.10.0
 	webfinger.net/go/webfinger v0.1.0
 )
@@ -77,7 +78,6 @@ require (
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect
 	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect


### PR DESCRIPTION
Generate the configuration by running `goreleaser init`. This got the basic
skeleton up and running. The only thing I had to add was making sure the license
was included within the archives.

I added a quick RELEASING guide. I think this ought to work, but let me know if
you have issues.
