### PR TITLE
explicitly state that `status-map-file` and `attachment-map-file` are output paths to be written by `slurp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Before proceeding, you might want to copy custom emojis from your old instance. 
 ./slurp --user user@instance.tld emojis import --file emojis.json
 ```
 
-Importing an archive requires that your archive be already uncompressed. (It should contain `actor.json` and `outbox.json` files, and a `media_attachments` folder.) Importing also requires two map files so that an interrupted import can be resumed. It is safe to interrupt an archive import: as long as you have your map files, this shouldn't result in duplicated statuses or media.
+Importing an archive requires that your archive be already uncompressed. (It should contain `actor.json` and `outbox.json` files, and a `media_attachments` folder.) Importing will also create two map files, so that an interrupted import can be resumed. It is safe to interrupt an archive import: as long as you have your map files, this shouldn't result in duplicated statuses or media.
 
 Depending on your rate limit settings for both `slurp` and your GTS instance, and how much media you have, an archive import may take minutes or hours.
 

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -98,8 +98,8 @@ func init() {
 
 	archiveImportCmd.PersistentFlags().StringVarP(&File, "file", "f", "", "path to import archive from (this must be an uncompressed folder for Mastodon)")
 	archiveImportCmd.PersistentFlags().StringVarP(&Format, "format", "t", "", "archive format can be one of: mastodon, pixelfed (default is mastodon)")
-	archiveImportCmd.PersistentFlags().StringVarP(&StatusMapFile, "status-map-file", "m", "", "JSON file to store mapping of archive status IDs to imported status IDs")
-	archiveImportCmd.PersistentFlags().StringVarP(&AttachmentMapFile, "attachment-map-file", "a", "", "JSON file to store mapping of archive media attachment paths IDs to media attachment IDs")
+	archiveImportCmd.PersistentFlags().StringVarP(&StatusMapFile, "status-map-file", "m", "", "path to write new JSON file to store mapping of archive status IDs to imported status IDs")
+	archiveImportCmd.PersistentFlags().StringVarP(&AttachmentMapFile, "attachment-map-file", "a", "", "path to write new JSON file to store mapping of archive media attachment paths IDs to media attachment IDs")
 	archiveImportCmd.PersistentFlags().StringVarP(&AttachmentDirectory, "attachment-directory", "d", "", "folder to store media downloaded from Pixelfed")
 	archiveImportCmd.PersistentFlags().BoolVarP(&AllowMissingCustomEmojis, "allow-missing-custom-emojis", "e", false, "import statuses for which the instance doesn't have all of the custom emojis")
 	archiveCmd.AddCommand(archiveImportCmd)


### PR DESCRIPTION
https://github.com/VyrCossont/slurp/issues/28#issuecomment-2845742919
> Something that should maybe be clearer in the documentation is that the attachment and status map files are created by slurp during the import process. Like they don't come with the archive and you don't have to manually make them. The command line options are just to specify what names the automatically created map files will have.
@nevillepark

I ran into this exact issue today; I very confused why I didn't have `status-map.json` or `attachment-map.json` in my archive, and thought I had done something wrong when exporting from Mastodoon