### PR TITLE
Add flag to ignore errors during emoji import

### DIFF
--- a/cmd/emojis.go
+++ b/cmd/emojis.go
@@ -63,12 +63,15 @@ var emojisImportCmd = &cobra.Command{
 			return err
 		}
 
-		return emojis.Import(authClient, File)
+		return emojis.Import(authClient, File, IgnoreErrors)
 	},
 }
 
 // Inline includes emojis in the exported emoji JSON as data: URLs.
 var Inline bool
+
+// IgnoreErrors determines whether to ignore errors during emoji import.
+var IgnoreErrors bool
 
 func init() {
 	rootCmd.AddCommand(emojisCmd)
@@ -78,5 +81,6 @@ func init() {
 	emojisCmd.AddCommand(emojisExportCmd)
 
 	emojisImportCmd.PersistentFlags().StringVarP(&File, "file", "f", "", "path to import emojis from (optional: stdin will be used if omitted)")
+	emojisImportCmd.PersistentFlags().BoolVarP(&IgnoreErrors, "ignore-errors", "", false, "whether to ignore errors during import")
 	emojisCmd.AddCommand(emojisImportCmd)
 }

--- a/internal/emojis/emojis.go
+++ b/internal/emojis/emojis.go
@@ -80,7 +80,7 @@ func Export(authClient *auth.Client, file string, inline bool) error {
 	return nil
 }
 
-func Import(authClient *auth.Client, file string) error {
+func Import(authClient *auth.Client, file string, ignoreErrors bool) error {
 	var emojis []*models.Emoji
 
 	var err error
@@ -159,7 +159,11 @@ func Import(authClient *auth.Client, file string) error {
 		)
 		if err != nil {
 			slog.Error("couldn't create emoji", "shortcode", emoji.Shortcode, "err", err)
-			return errors.WithStack(err)
+			if ignoreErrors {
+				continue
+			} else {
+				return errors.WithStack(err)
+			}
 		}
 		apiEmoji := response.GetPayload()
 


### PR DESCRIPTION
Fixes #23 

Adds option to ignore errors during emoji import.

```
./slurp --user user@instance.tld emojis import --file emojis.json --ignore-errors
```
