### PR TITLE
Fix outbox loading for Mastodon archives

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -102,7 +102,7 @@ func Import(
 		return err
 	}
 
-	outbox, err := util.LoadJSON[Outbox](file)
+	outbox, err := util.LoadJSON[Outbox](path.Join(file, "outbox.json"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #38 by correctly path-joining "outbox.json" to the directory